### PR TITLE
Hotfix: Show outbound link conversion goal on overview

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://abtestingforwp.com/
 Requires at least: 5.0
 Tested up to: 5.3.2
 Requires PHP: 5.6
-Stable tag: 1.14.0
+Stable tag: 1.14.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -78,6 +78,9 @@ You can find the [source and repository over at GitHub](https://github.com/Gaya/
 5. Integration with HTML Forms
 
 == Changelog ==
+= 1.14.1 =
+* Show outbound conversion goal on overview page
+
 = 1.14.0 =
 * Ability to track outbound links as a goal
 

--- a/ab-testing-for-wp.php
+++ b/ab-testing-for-wp.php
@@ -1,13 +1,13 @@
 <?php
 /**
  * @package ABTestingForWP
- * @version 1.14.0
+ * @version 1.14.1
  */
 /*
     Plugin Name: A/B Testing for WordPress
     Plugin URI: https://abtestingforwp.com
     Description: Easiest way to create split tests on your WordPress sites, right from the content editor!
-    Version: 1.14.0
+    Version: 1.14.1
     Author: CleverNode
     Author URI: https://theclevernode.com
     Text Domain: ab-testing-for-wp

--- a/cypress/integration/outbound.spec.ts
+++ b/cypress/integration/outbound.spec.ts
@@ -111,6 +111,9 @@ describe('Outbound link tracking', () => {
     cy.get('.ABTestWinning > :nth-child(3)')
       .last()
       .should('contain', '1');
+
+    // shows outbound link conversion
+    cy.contains(SITE);
   });
 
   it('Will track form submits to outbound links', () => {

--- a/cypress/integration/overview.spec.ts
+++ b/cypress/integration/overview.spec.ts
@@ -12,12 +12,16 @@ describe('Overview of created tests', () => {
     cy.logout();
   });
 
-  it('Lists inline tests created in posts / pages', () => {
+  it.only('Lists inline tests created in posts / pages', () => {
     // create new post
     cy.visitAdmin('post-new.php?skipOnboarding=1');
 
     // add default test
     cy.addBlockInEditor('A/B Test', 'Inline A/B Test');
+
+    // Change target post to "Hello World!"
+    cy.get('#inspector-select-control-3')
+      .select('Hello world!');
 
     // save post
     cy.savePost();
@@ -28,6 +32,9 @@ describe('Overview of created tests', () => {
 
     // shows test in list
     cy.contains('Inline A/B Test');
+
+    // shows test goal
+    cy.contains('Hello world!');
   });
 
   it('Lists stand alone tests', () => {

--- a/cypress/integration/overview.spec.ts
+++ b/cypress/integration/overview.spec.ts
@@ -12,7 +12,7 @@ describe('Overview of created tests', () => {
     cy.logout();
   });
 
-  it.only('Lists inline tests created in posts / pages', () => {
+  it('Lists inline tests created in posts / pages', () => {
     // create new post
     cy.visitAdmin('post-new.php?skipOnboarding=1');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-test-wordpress",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-test-wordpress",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "A/B Test right from your WordPress posts.",
   "main": "index.js",
   "scripts": {

--- a/src/php/data/ab-test-manager.php
+++ b/src/php/data/ab-test-manager.php
@@ -44,8 +44,8 @@ class ABTestManager {
     public function getAllTests($extraQuery = '') {
         $data = $this->wpdb->get_results("
         SELECT t.id, t.isEnabled, t.startedAt, t.title, t.control, t.postId, t.postGoal,
-        p1.post_type AS postType, p1.post_title AS postName, p2.post_title AS goalName,
-        p2.post_type AS goalType, t.isArchived,
+        t.postGoalType, p1.post_type AS postType, p1.post_title AS postName,
+        p2.post_title AS goalName, p2.post_type AS goalType, t.isArchived,
         (
             SELECT SUM(participants)
             FROM `{$this->variantTable}` AS v

--- a/src/php/registrations/register-admin-page.php
+++ b/src/php/registrations/register-admin-page.php
@@ -136,8 +136,15 @@ class RegisterAdminPage {
             function ($test) {
                 $test['startedAt'] = strtotime($test['startedAt']) * 1000;
 
-                if ($test['postGoal'] === '0') {
+                // if no goal is set, show placeholders
+                if ($test['postGoal'] === '0' || $test['postGoal'] === '') {
                     $test['goalName'] = '—';
+                }
+
+                // fill in conversion goal for outbound links
+                if ($test['postGoalType'] === 'outbound') {
+                    $test['goalName'] = $test['postGoal'];
+                    $test['goalLink'] = $test['postGoal'];
                 }
 
                 return $test;


### PR DESCRIPTION
Outbound links were not showing on the overview page. Adds functionality and tests