### PR TITLE
Added some permission_callback callbacks to standard Rest routes

### DIFF
--- a/src/php/registrations/register-rest.php
+++ b/src/php/registrations/register-rest.php
@@ -2,9 +2,11 @@
 
 namespace ABTestingForWP;
 
-class RegisterREST {
+class RegisterREST
+{
 
-    private function registerRestRoutes() {
+    private function registerRestRoutes()
+    {
         $renderer = new BlockRenderer();
         $tracker = new ABTestTracking();
         $stats = new ABTestStats();
@@ -19,7 +21,10 @@ class RegisterREST {
             [
                 'methods' => 'GET',
                 'callback' => [$renderer, 'resolveVariant'],
-            ]
+                'permission_callback' => function () {
+                    return current_user_can('edit_posts');
+                }
+            ],
         );
 
         register_rest_route(
@@ -28,7 +33,10 @@ class RegisterREST {
             [
                 'methods' => 'GET',
                 'callback' => [$tracker, 'trackPage'],
-            ]
+                'permission_callback' => function () {
+                    return current_user_can('edit_posts');
+                }
+            ],
         );
 
         register_rest_route(
@@ -37,6 +45,9 @@ class RegisterREST {
             [
                 'methods' => 'POST',
                 'callback' => [$tracker, 'trackLink'],
+                'permission_callback' => function () {
+                    return current_user_can('edit_posts');
+                }
             ]
         );
 


### PR DESCRIPTION
I was getting a bunch of notices regarding a missing `permission_callback` argument. I've added the already existing `current_user_can` to all routes.

<img width="1425" alt="Screenshot 2020-10-29 at 08 56 09" src="https://user-images.githubusercontent.com/1636310/97559250-18383f80-19d5-11eb-8743-a7085704bce2.png">
